### PR TITLE
✨ feat: added /starters page

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/02-bug.yaml
@@ -8,7 +8,7 @@ body:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
       label: Bug Report Checklist
       options:
-        - label: I have [searched for related issues](https://github.com/LearningTypeScript/projects/issues?q=is%3Aissue+label%3A%22type%3A+bug%22) and found none that matched my issue.
+        - label: I have [searched for related issues](https://github.com/LearningTypeScript/site/issues?q=is%3Aissue+label%3A%22type%3A+bug%22) and found none that matched my issue.
           required: true
         - label: This is the appropriate issue form for the bug I would like to report.
           required: true

--- a/.github/ISSUE_TEMPLATE/03-starter.yaml
+++ b/.github/ISSUE_TEMPLATE/03-starter.yaml
@@ -1,0 +1,29 @@
+name: "🚀 Request a Starter"
+description: "Request a new starter be added to https://learningtypescript.com/starters"
+title: "🚀 Starter: <name of the starter framework/toolchain>"
+labels:
+  - "type: starter"
+body:
+  - attributes:
+      description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
+      label: Starter Request Checklist
+      options:
+        - label: I have [searched for related issues](https://github.com/LearningTypeScript/site/issues?q=is%3Aissue+label%3A%22area%3A+starters%22) and found none that matched my issue.
+          required: true
+        - label: This is the appropriate issue form for the starter I would like to request.
+          required: true
+    type: checkboxes
+  - attributes:
+      description: What is the docs URL of the starter framework/toolchain you'd like to request?
+      label: Starter Docs URL
+    type: textarea
+    validations:
+      required: true
+  - attributes:
+      description: What is the starter's guide to using TypeScript, if it exists?
+      label: Starter TypeScript Guide
+    type: textarea
+  - attributes:
+      label: Additional Info
+      description: Any additional info you'd like to provide.
+    type: textarea

--- a/.github/ISSUE_TEMPLATE/04-tooling.yaml
+++ b/.github/ISSUE_TEMPLATE/04-tooling.yaml
@@ -10,7 +10,7 @@ body:
       options:
         - label: I have pulled the latest `main` branch of the repository.
           required: true
-        - label: I have [searched for related issues](https://github.com/LearningTypeScript/projects/issues?q=is%3Aissue+label%3A%22area%3A+tooling) and found none that matched my request.
+        - label: I have [searched for related issues](https://github.com/LearningTypeScript/site/issues?q=is%3Aissue+label%3A%22area%3A+tooling) and found none that matched my request.
           required: true
         - label: This is the appropriate issue form for the tooling issue I would like to report.
           required: true

--- a/.github/ISSUE_TEMPLATE/05-documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/05-documentation.yaml
@@ -11,7 +11,7 @@ body:
       options:
         - label: I have pulled the latest `main` branch of the repository.
           required: true
-        - label: I have [searched for related issues](https://github.com/LearningTypeScript/projects/issues?q=is%3Aissue+label%3A%22area%3A+documentation) and found none that matched my request.
+        - label: I have [searched for related issues](https://github.com/LearningTypeScript/site/issues?q=is%3Aissue+label%3A%22area%3A+documentation) and found none that matched my request.
           required: true
         - label: This is the appropriate issue form for the documentation issue I would like to report.
           required: true

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -139,6 +139,11 @@ const config = {
             to: "/projects",
           },
           {
+            label: "Starters",
+            position: "right",
+            to: "/starters",
+          },
+          {
             href: "https://www.oreilly.com/library/view/learning-typescript/9781098110321",
             label: "The Book",
             position: "right",

--- a/src/pages/starters/index.tsx
+++ b/src/pages/starters/index.tsx
@@ -1,0 +1,66 @@
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import Layout from "@theme/Layout";
+import { useChapters } from "@site/src/utils/useChapters";
+import React from "react";
+
+import { Card, CardProps } from "../../theme/Card";
+import { MainArea } from "../../theme/MainArea";
+import styles from "./styles.module.css";
+import { OutlineLink } from "@site/src/theme/OutlineLink";
+
+const starters: CardProps[] = [
+  {
+    description:
+      "Angular is an application design framework and development platform for creating efficient and sophisticated single-page apps.",
+    href: "https://angular.io/guide/typescript-configuration",
+    title: "Angular",
+  },
+  {
+    description:
+      "Next.js is a popular React framework that provides building blocks for fully interactive and performant full stack apps.",
+    href: "https://nextjs.org/docs/basic-features/typescript",
+    title: "Next.js",
+  },
+  {
+    description:
+      "Remix is an up-and-coming, already popular React framework that enhances web APIs for seamlessly performant full stack apps.",
+    href: "https://remix.run/docs/en/v1/guides/typescript",
+    title: "Remix",
+  },
+  {
+    description:
+      "An approachable, performant and versatile framework for building web user interfaces with an intuitive API.",
+    href: "https://vuejs.org/guide/typescript/overview.html",
+    title: "Vue",
+  },
+].sort((a, b) => a.title.localeCompare(b.title));
+
+export default function Starters(): JSX.Element {
+  const { siteConfig } = useDocusaurusContext();
+
+  return (
+    <Layout description={siteConfig.tagline} title="Starters">
+      <MainArea as="main" className={styles.mainArea}>
+        <h1 className={styles.heading}>Starters</h1>
+        <p>
+          Links to recommended getting-started / "Hello World" starters for
+          common frameworks and toolchains with TypeScript.
+        </p>
+        <div className={styles.starters}>
+          {starters.map((starter) => {
+            return (
+              <Card className={styles.card} {...starter} key={starter.title} />
+            );
+          })}
+        </div>
+        <p className={styles.ad}>Want a template not yet on this list?</p>
+        <OutlineLink
+          className={styles.link}
+          href="https://github.com/LearningTypeScript/site/issues/new/choose"
+        >
+          Request One Here
+        </OutlineLink>
+      </MainArea>
+    </Layout>
+  );
+}

--- a/src/pages/starters/styles.module.css
+++ b/src/pages/starters/styles.module.css
@@ -11,7 +11,11 @@
 }
 
 .ad {
-  margin-top: 2rem;
+  margin-top: 3rem;
+}
+
+.link {
+  display: inline-block;
 }
 
 /* Todo: use var(--lt-media-query-width-medium)? */

--- a/src/pages/starters/styles.module.css
+++ b/src/pages/starters/styles.module.css
@@ -1,0 +1,26 @@
+.mainArea {
+  padding: 2rem;
+}
+
+.starters {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 3rem;
+  margin-top: 3rem;
+}
+
+.ad {
+  margin-top: 2rem;
+}
+
+/* Todo: use var(--lt-media-query-width-medium)? */
+@media (min-width: 768px) {
+  .card {
+    width: calc(50% - 1.5rem);
+  }
+
+  .mainArea {
+    padding: 2rem 0;
+  }
+}

--- a/src/theme/Card/index.tsx
+++ b/src/theme/Card/index.tsx
@@ -7,7 +7,7 @@ export interface CardProps {
   className?: string;
   description: string;
   href: string;
-  meta: string;
+  meta?: string;
   title: string;
 }
 
@@ -22,7 +22,7 @@ export const Card = ({
     <a className={clsx(styles.card, className)} href={href}>
       <div className={styles.title}>{title}</div>
       <div className={styles.description}>{description}</div>
-      <div className={styles.meta}>{meta}</div>
+      {meta && <div className={styles.meta}>{meta}</div>}
     </a>
   );
 };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/site/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds an initial https://learningtypescript.com/starters with four projects. Also fixes a few issue template link typos, heh.

I'll push-to-main the right URL for the button once I can get the autogenerated URL from GitHub...