### PR TITLE
🐛: fix editUrl for docs (projects)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -111,7 +111,8 @@ const config = {
           showReadingTime: true,
         },
         docs: {
-          editUrl: "https://github.com/LearningTypeScript/projects/tree/main/",
+          editUrl: ({ docPath }) =>
+            `https://github.com/LearningTypeScript/projects/tree/main/projects/${docPath}`,
           include: ["*/*.md", "*/*/*.md"],
           path: "src/content/external/projects",
           remarkPlugins: [[externalProjectLinks, {}]],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #38
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/site/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixes the edit URL to be a join on the `main` branch -> `projects/` plus the computed `docsPath`.