### PR TITLE
✨ feat: added custom 404 page

### DIFF
--- a/src/theme/NotFound/index.tsx
+++ b/src/theme/NotFound/index.tsx
@@ -1,0 +1,35 @@
+import { useLocation } from "@docusaurus/router";
+import { PageMetadata } from "@docusaurus/theme-common";
+import Layout from "@theme/Layout";
+import React from "react";
+import { MainArea } from "../MainArea";
+
+import styles from "./styles.module.css";
+
+export default function NotFound() {
+  const location = useLocation();
+
+  return (
+    <>
+      <PageMetadata title={"Page Not Found"} />
+      <Layout>
+        <MainArea className={styles.mainArea}>
+          <main className="container margin-vert--xl">
+            <h1 className={styles.title}>
+              Error: Cannot find name '{location.pathname}'.
+            </h1>
+            <p>Looks like the page you're looking for doesn't exist. 😥</p>
+            <p>
+              If you were linked here within learningtypescript.com, there's
+              probably a bug in the site. Please{" "}
+              <a href="https://github.com/LearningTypeScript/site/issues/new/choose">
+                file an issue on GitHub
+              </a>
+              .
+            </p>
+          </main>
+        </MainArea>
+      </Layout>
+    </>
+  );
+}

--- a/src/theme/NotFound/styles.module.css
+++ b/src/theme/NotFound/styles.module.css
@@ -1,0 +1,15 @@
+.mainArea a {
+  --ifm-link-decoration: underline;
+}
+
+.title {
+  font-family: monospace;
+  font-size: 3rem;
+  margin-bottom: 2rem;
+}
+
+.title::before {
+  content: "$ tsc > ...";
+  display: block;
+  font-size: 1.5rem;
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #3
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/site/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Swizzles the `NotFound` component per https://github.com/facebook/docusaurus/discussions/6030 -> https://docusaurus.io/docs/swizzling#swizzling-theme-components.

![Screenshot of the 404 page with an error url](https://user-images.githubusercontent.com/3335181/180618652-c847f623-6896-4833-921b-9179884dfaba.png)
