### PR TITLE
🐛 fix: remove faulty breadcrumbs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -118,6 +118,7 @@ const config = {
           showReadingTime: true,
         },
         docs: {
+          breadcrumbs: false,
           editUrl: ({ docPath }) =>
             `https://github.com/LearningTypeScript/projects/tree/main/projects/${docPath}`,
           include: ["*/*.md", "*/*/*.md"],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #25
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/site/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Breadcrumbs aren't very customizeable yet (#6953), so in the meantime this just removes them. Ah well.
