### PR TITLE
🐛 fix: footer icon alignments

### DIFF
--- a/src/theme/Footer/styles.module.css
+++ b/src/theme/Footer/styles.module.css
@@ -35,10 +35,10 @@
 
 .icons {
   display: flex;
+  flex-direction: row;
   gap: 1rem;
-  flex-direction: column;
+  justify-content: center;
   margin-bottom: 2rem;
-  align-items: flex-end;
 }
 
 .icon {
@@ -75,6 +75,10 @@
 
   .getTheBook {
     margin-top: 2px;
+  }
+
+  .icons {
+    justify-content: flex-end;
   }
 
   .credits {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #79
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/site/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixes up the flex alignment for the footer icons to be horizontal on mobile.