### PR TITLE
fix: increase dark mode text contrast

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -18,6 +18,9 @@
 
 [data-theme="dark"] {
   --ifm-background-deemphasized-color: #222024;
+  --ifm-link-color: #f4f1f8;
+  --ifm-menu-color-active: var(--ifm-link-color);
+  --ifm-color-primary: var(--ifm-link-color);
 }
 
 .docusaurus-highlight-code-line {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #89
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/site/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img alt="Before screenshot with dark links" src="https://user-images.githubusercontent.com/3335181/190373402-a4793590-35aa-4d9e-bc1a-d25d245ea770.png" />
</td>
<td>
<img alt="Light screenshot with light links" src="https://user-images.githubusercontent.com/3335181/190373352-115f0494-d1b2-462a-ab1e-6c10203e5e22.png" />
</td>
</tr>
</tbody>
</table>