### PR TITLE
fix: remove Books dropdown visibility when hidden

### DIFF
--- a/src/theme/NavbarItem/DropdownLinkItem/styles.module.css
+++ b/src/theme/NavbarItem/DropdownLinkItem/styles.module.css
@@ -14,12 +14,14 @@
   text-align: right;
   top: 50%;
   transition: opacity var(--ifm-transition-fast), top var(--ifm-transition-fast);
+  visibility: hidden;
 }
 
 .dropdownLinkItem:focus-within .links,
 .dropdownLinkItem:hover .links {
   opacity: 1;
   top: 100%;
+  visibility: visible;
 }
 
 .links a {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #91
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/site/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Hides the dropdown with `visibility: hidden` when not focused or hovered.