### PR TITLE
fix: plugin order for Markdown copy button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -144,12 +144,12 @@ const config = {
           showReadingTime: true,
         },
         docs: {
+          beforeDefaultRemarkPlugins: [[externalProjectLinks, {}]],
           breadcrumbs: false,
           editUrl: ({ docPath }) =>
             `https://github.com/LearningTypeScript/projects/tree/main/projects/${docPath}`,
           include: ["*/*.md", "*/*/*.md"],
           path: "src/content/external/projects",
-          beforeDefaultRemarkPlugins: [[externalProjectLinks, {}]],
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
         },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -149,7 +149,7 @@ const config = {
             `https://github.com/LearningTypeScript/projects/tree/main/projects/${docPath}`,
           include: ["*/*.md", "*/*/*.md"],
           path: "src/content/external/projects",
-          remarkPlugins: [[externalProjectLinks, {}]],
+          beforeDefaultRemarkPlugins: [[externalProjectLinks, {}]],
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
         },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #96
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/site/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The issue is that the `external-project-links.js` Remark plugin is running after the default Docusaurus ones. It should be in a `beforeDefaultRemarkPlugins` entry in `docusaurus.config.js.