### PR TITLE
Fix: move docusaurus-preset-shiki-twoslash before classic preset

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -127,6 +127,12 @@ const config = {
 
   presets: [
     [
+      "docusaurus-preset-shiki-twoslash",
+      {
+        themes: ["min-light", "nord"],
+      },
+    ],
+    [
       "classic",
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
@@ -157,12 +163,6 @@ const config = {
           customCss: require.resolve("./src/css/custom.css"),
         },
       }),
-    ],
-    [
-      "docusaurus-preset-shiki-twoslash",
-      {
-        themes: ["min-light", "nord"],
-      },
     ],
   ],
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #102
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/site/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Makes the shiki preset apply before all the normal classic preset stuff. Similar fix to #98.