### PR TITLE
Fix broken link in: Update the-satisfies-operator.mdx

### DIFF
--- a/src/content/articles/the-satisfies-operator.mdx
+++ b/src/content/articles/the-satisfies-operator.mdx
@@ -196,7 +196,7 @@ You can also try out the latest ("nightly") version of TypeScript in your browse
 The `satisfies` operator was designed and released after the _Learning TypeScript_ book's contents were finalized.
 `satisfies` is not mentioned in _Learning TypeScript_.
 
-Still, _Learning TypeScript_'s [The Type System chapter](http://localhost:3000/the-type-system) teaches all the concepts you'll need to be able to understand TypeScript's type system.
+Still, _Learning TypeScript_'s [The Type System chapter](https://www.learningtypescript.com/the-type-system) teaches all the concepts you'll need to be able to understand TypeScript's type system.
 That includes how the type system works, the default type inferences mentioned in this article, and explicitly using `:` type annotations.
 
 ## Thanks


### PR DESCRIPTION
## Overview

This PR fixes a broken link on the page: `Update the-satisfies-operator.mdx`.
Changes link from: `http://localhost:3000` to `https://www.learningtypescript.com`.

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/site/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/site/blob/main/.github/CONTRIBUTING.md) were taken