### PR TITLE
fix: Shiki twoslash error displays are visually offset slightly

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -90,6 +90,15 @@
   display: none;
 }
 
+pre.shiki.nord > .code-container {
+  padding: var(--ifm-pre-padding);
+}
+
+pre.shiki.nord > .code-container > code {
+  display: block;
+  position: relative;
+}
+
 /* Override for inaccessible (barely visible) light mode comments */
 .shiki.min-light span[style="color: rgb(194, 195, 197);"],
 .shiki.min-light span[style="color:#C2C3C5"] {

--- a/src/theme/CodeBlock/index.tsx
+++ b/src/theme/CodeBlock/index.tsx
@@ -12,13 +12,11 @@ export default function CodeBlockWrapper({
   ...props
 }: CodeBlockWrapperProps) {
   return (
-    <>
-      <CodeBlock
-        className={clsx("shiki hihi", styles.codeBlock, className)}
-        {...props}
-      >
-        {children}
-      </CodeBlock>
-    </>
+    <CodeBlock
+      className={clsx("shiki hihi", styles.codeBlock, className)}
+      {...props}
+    >
+      {children}
+    </CodeBlock>
   );
 }

--- a/src/theme/CodeBlock/index.tsx
+++ b/src/theme/CodeBlock/index.tsx
@@ -17,9 +17,7 @@ export default function CodeBlockWrapper({
         className={clsx("shiki hihi", styles.codeBlock, className)}
         {...props}
       >
-        <div className="code-container line">
-          <code>{children}</code>
-        </div>
+        {children}
       </CodeBlock>
     </>
   );


### PR DESCRIPTION
As promised... 😄 

Closes #117

Before:
![image](https://github.com/LearningTypeScript/site/assets/32631382/9d177d02-f2b4-4253-8da8-e400dd8bc9ea)


After:
![image](https://github.com/LearningTypeScript/site/assets/32631382/799259e6-e841-4cb3-a618-ff4887a9fe80)
