### PR TITLE
fix: missing padding in projects code block

### DIFF
--- a/src/pages/projects/index.tsx
+++ b/src/pages/projects/index.tsx
@@ -89,9 +89,15 @@ export default function Projects(): JSX.Element {
           repository locally:
         </p>
         <CodeBlock language="shell">
-          {`git clone https://github.com/LearningTypeScript/projects learning-typescript-projects
+          <div className="code-container line">
+              <code>
+                {
+                `git clone https://github.com/LearningTypeScript/projects learning-typescript-projects
 cd learning-typescript-projects
-npm i`}
+npm i`
+                }
+              </code>
+          </div>
         </CodeBlock>
         <div className={styles.chapters}>
           {chapterNames.map((chapterName, index) => {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to LearningTypescript! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #126 
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/site/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
It looks like the `code-container` div is injected from `twoslash`,
since we render the code block manually, the code isn't nested inside a code-container div (which is padded).

Seems like it happened due to the changes in #122

Closes #126 ✅
