### PR TITLE
replace 404 link with working link for compat table

### DIFF
--- a/src/content/articles/why-increase-your-tsconfig-target.mdx
+++ b/src/content/articles/why-increase-your-tsconfig-target.mdx
@@ -179,7 +179,7 @@ _Learning TypeScript_ recommends using the highest possible ECMAScript target su
 In other words, you'll want to pick the oldest ECMAScript environment target that your code might run in - and no older.
 Picking as new a `compilerOptions.target` as possible improves both the output code your users run and your development experience of using TypeScript.
 
-The [kangax compatibility table](https://kangax.github.io/compat-table/es2016plus) is an excellent tool for determining which features are supported in each environment.
+The [compatibility table](https://compat-table.github.io/compat-table/es2016plus) is an excellent tool for determining which features are supported in each environment.
 It includes a list of all the runtime features added in each ECMAScript version, along with whether they're supported in many popular JavaScript environments.
 
 ### Browser Apps


### PR DESCRIPTION
kangax compatibility table
 links to a 404 github page

i think the correct page has moved to

https://compat-table.github.io/compat-table/es2016plus/

<!-- 👋 Hi, thanks for sending a PR to LearningTypescript! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/site/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
